### PR TITLE
Use mio-serial approach to Windows COMM Timeouts[CPP-657]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
This is how mio-serial sets up their COMM timeouts that differs from serialport-rs. It appears to improve performance but there is still a significant delay compared to linux.